### PR TITLE
避免在其他文件import时出现TypeError的错误

### DIFF
--- a/src/components/treeTable/index.js
+++ b/src/components/treeTable/index.js
@@ -7,6 +7,4 @@
 
 import TreeGrid from './vue/TreeGrid.vue'
 
-module.exports = {
-  TreeGrid
-}
+export {TreeGrid}


### PR DESCRIPTION
在引用import的时候 出现TypeError: "exports" is read-only，照这个issue修改后可以引入。
https://github.com/webpack/webpack/issues/4039